### PR TITLE
Disable the ossec-authd service since we don't need it!

### DIFF
--- a/manager_clients/wazuh-manager-client-conf.yaml
+++ b/manager_clients/wazuh-manager-client-conf.yaml
@@ -221,7 +221,7 @@ data:
         ossec-control enable auth
       -->
       <auth>
-        <disabled>no</disabled>
+        <disabled>yes</disabled>
         <port>1515</port>
         <use_source_ip>no</use_source_ip>
         <force_insert>no</force_insert>

--- a/manager_clients/wazuh-manager-client-sts.yaml
+++ b/manager_clients/wazuh-manager-client-sts.yaml
@@ -65,7 +65,6 @@ spec:
               mountPath: /etc/postfix
           ports:
             - containerPort: 1514
-            - containerPort: 1515
             - containerPort: 1516
             - containerPort: 55000
   volumeClaimTemplates:

--- a/manager_master/wazuh-manager-master-conf.yaml
+++ b/manager_master/wazuh-manager-master-conf.yaml
@@ -221,7 +221,7 @@ data:
         ossec-control enable auth
       -->
       <auth>
-        <disabled>no</disabled>
+        <disabled>yes</disabled>
         <port>1515</port>
         <use_source_ip>no</use_source_ip>
         <force_insert>no</force_insert>

--- a/manager_master/wazuh-manager-master-sts.yaml
+++ b/manager_master/wazuh-manager-master-sts.yaml
@@ -49,7 +49,6 @@ spec:
               mountPath: /etc/postfix
           ports:
             - containerPort: 1514
-            - containerPort: 1515
             - containerPort: 1516
             - containerPort: 55000
   volumeClaimTemplates:

--- a/manager_master/wazuh-manager-svc.yaml
+++ b/manager_master/wazuh-manager-svc.yaml
@@ -26,6 +26,3 @@ spec:
     - name: agents-events
       port: 1514
       targetPort: 1514
-    - name: agents-auth
-      port: 1515
-      targetPort: 1515


### PR DESCRIPTION
Since we are using the Wazuh API to register new Agents, we don't need the ossec-authd service. I disabled it then I stopped exposing the port 1515.