### PR TITLE
Fixes for the cluster K8S services and random improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ pushd manager_cluster
 
 kubectl apply -f wazuh-api-svc.yaml
 kubectl apply -f wazuh-manager-cluster-sts-svc.yaml
-kubectl apply -f wazuh-manager-svc.yaml
+kubectl apply -f wazuh-workers-svc.yaml
 
 kubectl apply -f wazuh-manager-master-conf.yaml
 kubectl apply -f wazuh-manager-worker-0-conf.yaml

--- a/elasticsearch/elasticsearch-sts.yaml
+++ b/elasticsearch/elasticsearch-sts.yaml
@@ -8,7 +8,7 @@
 # repository is a nice example!
 #######################################################################
 
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: wazuh-elasticsearch

--- a/kibana/kibana-deploy.yaml
+++ b/kibana/kibana-deploy.yaml
@@ -2,7 +2,7 @@
 # Kubernetes Deployment for Wazuh Kibana container
 #######################################################################
 
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: wazuh-kibana

--- a/kibana/nginx-deploy.yaml
+++ b/kibana/nginx-deploy.yaml
@@ -2,7 +2,7 @@
 # Kubernetes Deployment for Wazuh Kibana nginx proxy container
 #######################################################################
 
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: wazuh-nginx

--- a/logstash/logstash-deploy.yaml
+++ b/logstash/logstash-deploy.yaml
@@ -2,7 +2,7 @@
 # Kubernetes Deployment for the Wazuh Logstash container
 #######################################################################
 
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: wazuh-logstash

--- a/manager_cluster/README.md
+++ b/manager_cluster/README.md
@@ -4,12 +4,12 @@ This directory contains Kubernetes configurations which runs Wazuh manager Pod a
 This directory also contains two services that should be exposed internally in your AWS VPC:
 * The `wazuh` service which exposes the Wazuh API of the master node
 * The `wazuh-cluster` service which allow the communication between all Wazuh manager pods
-* The `wazuh-manager` service which exposes the Wazuh managers agents management ports
+* The `wazuh-workers` service which exposes Wazuh workers agents management ports
 
 ## Before deploying
 Make sure you deployed everything from the [base](../base) folder, the [elasticsearch](../elasticsearch) folder, the [kibana](../kibana) folder and [logstash](../logstash) folder the before deploying the Wazuh manager cluster.
 
-Then, you will need to update the `domainName` annotation value in both the [wazuh-api-svc.yaml](wazuh-api-svc.yaml) and the [wazuh-manager-svc.yaml](wazuh-manager-svc.yaml) files before deploying those services.
+Then, you will need to update the `domainName` annotation value in both the [wazuh-api-svc.yaml](wazuh-api-svc.yaml) and the [wazuh-manager-svc.yaml](wazuh-workers-svc.yaml) files before deploying those services.
 
 You should also set a valid AWS ACM certificate ARN in the [wazuh-api-svc.yaml](wazuh-api-svc.yaml) for the `service.beta.kubernetes.io/aws-load-balancer-ssl-cert` annotation. That certificate should match with the `domainName`.
 
@@ -17,7 +17,7 @@ You should also set a valid AWS ACM certificate ARN in the [wazuh-api-svc.yaml](
 ```BASH
 kubectl apply -f wazuh-api-svc.yaml
 kubectl apply -f wazuh-manager-cluster-sts-svc.yaml
-kubectl apply -f wazuh-manager-svc.yaml
+kubectl apply -f wazuh-workers-svc.yaml
 
 kubectl apply -f wazuh-manager-master-conf.yaml
 kubectl apply -f wazuh-manager-worker-0-conf.yaml

--- a/manager_cluster/wazuh-api-svc.yaml
+++ b/manager_cluster/wazuh-api-svc.yaml
@@ -21,8 +21,11 @@ spec:
   type: LoadBalancer
   selector:
     app: wazuh-manager
-    wazuh-manager-role: master
+    node-type: master
   ports:
+    - name: ossec-authd
+      port: 1515
+      targetPort: 1515
     - name: wazuh-api
       port: 55000
       targetPort: 55000

--- a/manager_cluster/wazuh-manager-cluster-sts-svc.yaml
+++ b/manager_cluster/wazuh-manager-cluster-sts-svc.yaml
@@ -8,10 +8,10 @@ metadata:
   name: wazuh-cluster
   namespace: wazuh
   labels:
-    app: wazuh-master
+    app: wazuh-manager
 spec:
   selector:
-    wazuh-manager-role: master
+    app: wazuh-manager
   ports:
     - name: wazuh-clusterd
       port: 1516

--- a/manager_cluster/wazuh-manager-master-sts.yaml
+++ b/manager_cluster/wazuh-manager-master-sts.yaml
@@ -5,7 +5,7 @@
 # a multi-master setup
 #######################################################################
 
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: wazuh-manager-master
@@ -15,14 +15,14 @@ spec:
   selector:
     matchLabels:
       app: wazuh-manager
-      wazuh-manager-role: master
+      node-type: master
   serviceName: wazuh-cluster
   podManagementPolicy: Parallel
   template:
     metadata:
       labels:
         app: wazuh-manager
-        wazuh-manager-role: master
+        node-type: master
       name: wazuh-manager-master
     spec:
       volumes:
@@ -49,10 +49,12 @@ spec:
             - name: wazuh-manager-master
               mountPath: /etc/postfix
           ports:
-            - containerPort: 1514
             - containerPort: 1515
+              name: ossec-authd
             - containerPort: 1516
+              name: wazuh-clusterd
             - containerPort: 55000
+              name: wazuh-api
   volumeClaimTemplates:
     - metadata:
         name: wazuh-manager-master

--- a/manager_cluster/wazuh-manager-worker-0-sts.yaml
+++ b/manager_cluster/wazuh-manager-worker-0-sts.yaml
@@ -1,12 +1,14 @@
 #######################################################################
-# Kubernetes StatefulSet for Wazuh manager worker nodes
+# Kubernetes StatefulSet for Wazuh manager worker-0 node
 #
-# We deploy two replicas here and we set a Pod anti-affinity policy to
-# make sure the master and worker pods are not all running on the same
-# Kubernetes node.
+# We have 3 StatefulSet because the Manager configuration requires the
+# node_name to be unique for each cluster member.
+#
+# https://github.com/wazuh/wazuh/issues/1329 will allow us to go back
+# to a single StatefulSet for all workers.
 #######################################################################
 
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: wazuh-manager-worker-0
@@ -16,14 +18,16 @@ spec:
   selector:
     matchLabels:
       app: wazuh-manager
-      wazuh-manager-role: worker-0
+      node-type: worker
+      sts-id: '0'
   serviceName: wazuh-cluster
   podManagementPolicy: Parallel
   template:
     metadata:
       labels:
         app: wazuh-manager
-        wazuh-manager-role: worker-0
+        node-type: worker
+        sts-id: '0'
       name: wazuh-manager-worker-0
     spec:
       affinity:
@@ -33,10 +37,10 @@ spec:
               podAffinityTerm:
                 labelSelector:
                   matchExpressions:
-                    - key: wazuh-manager-role
+                    - key: sts-id
                       operator: In
                       values:
-                        - master
+                        - '1'
                 topologyKey: kubernetes.io/hostname
       volumes:
         - name: config
@@ -63,9 +67,9 @@ spec:
               mountPath: /etc/postfix
           ports:
             - containerPort: 1514
-            - containerPort: 1515
+              name: agents-events
             - containerPort: 1516
-            - containerPort: 55000
+              name: wazuh-clusterd
   volumeClaimTemplates:
     - metadata:
         name: wazuh-manager-worker

--- a/manager_cluster/wazuh-manager-worker-1-sts.yaml
+++ b/manager_cluster/wazuh-manager-worker-1-sts.yaml
@@ -1,12 +1,14 @@
 #######################################################################
-# Kubernetes StatefulSet for Wazuh manager worker nodes
+# Kubernetes StatefulSet for Wazuh manager worker-1 node
 #
-# We deploy two replicas here and we set a Pod anti-affinity policy to
-# make sure the master and worker pods are not all running on the same
-# Kubernetes node.
+# We have 3 StatefulSet because the Manager configuration requires the
+# node_name to be unique for each cluster member.
+#
+# https://github.com/wazuh/wazuh/issues/1329 will allow us to go back
+# to a single StatefulSet for all workers.
 #######################################################################
 
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: wazuh-manager-worker-1
@@ -16,14 +18,16 @@ spec:
   selector:
     matchLabels:
       app: wazuh-manager
-      wazuh-manager-role: worker-1
+      node-type: worker
+      sts-id: '1'
   serviceName: wazuh-cluster
   podManagementPolicy: Parallel
   template:
     metadata:
       labels:
         app: wazuh-manager
-        wazuh-manager-role: worker-1
+        node-type: worker
+        sts-id: '1'
       name: wazuh-manager-worker-1
     spec:
       affinity:
@@ -33,10 +37,10 @@ spec:
               podAffinityTerm:
                 labelSelector:
                   matchExpressions:
-                    - key: wazuh-manager-role
+                    - key: sts-id
                       operator: In
                       values:
-                        - master
+                        - '0'
                 topologyKey: kubernetes.io/hostname
       volumes:
         - name: config
@@ -63,9 +67,9 @@ spec:
               mountPath: /etc/postfix
           ports:
             - containerPort: 1514
-            - containerPort: 1515
+              name: agents-events
             - containerPort: 1516
-            - containerPort: 55000
+              name: wazuh-clusterd
   volumeClaimTemplates:
     - metadata:
         name: wazuh-manager-worker

--- a/manager_cluster/wazuh-workers-svc.yaml
+++ b/manager_cluster/wazuh-workers-svc.yaml
@@ -10,7 +10,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: wazuh-manager
+  name: wazuh-workers
   namespace: wazuh
   labels:
     app: wazuh-manager
@@ -22,10 +22,8 @@ spec:
   type: LoadBalancer
   selector:
     app: wazuh-manager
+    node-type: worker
   ports:
     - name: agents-events
       port: 1514
       targetPort: 1514
-    - name: agents-auth
-      port: 1515
-      targetPort: 1515


### PR DESCRIPTION
\! Fix the wazuh-cluster Service selector
\* Close ports 1515 and 55000 for workers, should never be used
\! Fix workers anti-affinity policy until we can merger our two worker StatefulSet
\* Rename the wazuh-manager service for wazuh-workers, expose only workers with that service (recommendation from a Wazuh developer)
\* Close the port 1514 on the master (recommendation from a Wazuh developer)
\* Use official versions of Kubernetes APIs